### PR TITLE
update sofa ark version

### DIFF
--- a/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
+++ b/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
@@ -67,6 +67,6 @@ Note: Users can choose Koupleless versions according to their actual JDK and Spr
 
 | JDK | SpringBoot   | SOFAARK | Koupleless |
 |-----|--------------|---------|------------|
-| 1.8 | 2.x          | 2.2.9   | 1.x.x      |
+| 1.8 | 2.x          | 2.2.10  | 1.x.x      |
 | 17  | 3.0.x, 3.1.x | 3.0.x   | 2.0.x      |
 | 17  | 3.2.x and above | 3.1.x   | 2.1.x     |

--- a/content/zh-cn/docs/tutorials/base-create/springboot-and-sofaboot.md
+++ b/content/zh-cn/docs/tutorials/base-create/springboot-and-sofaboot.md
@@ -27,7 +27,7 @@ spring.application.name = ${替换为实际基座应用名}
 
 ```xml
 <properties>
-    <sofa.ark.verion>2.2.9</sofa.ark.verion>
+    <sofa.ark.verion>2.2.10</sofa.ark.verion>
     <!-- 不同jdk版本，使用不同koupleless版本，参考：https://koupleless.io/docs/tutorials/module-development/runtime-compatibility-list/#%E6%A1%86%E6%9E%B6%E8%87%AA%E8%BA%AB%E5%90%84%E7%89%88%E6%9C%AC%E5%85%BC%E5%AE%B9%E6%80%A7%E5%85%B3%E7%B3%BB -->
     <koupleless.runtime.version>1.2.0</koupleless.runtime.version>
 </properties>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `SOFAARK` version from `2.2.9` to `2.2.10` in the compatibility list for JDK 1.8.
  - Updated `sofa.ark.version` from `2.2.9` to `2.2.10` in the XML configuration for Spring Boot and SOFABoot tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->