### PR TITLE
add apache coc ppt

### DIFF
--- a/content/en/blog/external-articles-and-videos.md
+++ b/content/en/blog/external-articles-and-videos.md
@@ -8,6 +8,10 @@ description: Essential articles and videos for Koupleless
 
 ## Technical Conferences
 
+### 2024 Apache COC
+helo on: 20240726
+Meeting PPT: [点击此处下载](https://serverless-opensource.oss-cn-shanghai.aliyuncs.com/outer-materials/%E3%80%90apache%20coc%202024%E3%80%91%E5%BE%AE%E6%9C%8D%E5%8A%A1%E4%B8%8B%E4%B8%80%E7%AB%99%EF%BC%8CKoupleless%20%E6%A8%A1%E5%9D%97%E5%8C%96%E7%A0%94%E5%8F%91%E6%A1%86%E6%9E%B6%E4%B8%8E%E8%BF%90%E7%BB%B4%E8%B0%83%E5%BA%A6%E7%B3%BB%E7%BB%9F-v2.0.pdf?Expires=1721990001&OSSAccessKeyId=TMP.3KiUjg1m2mc2LyZV76WyqYdJVi3b3jDnpeoFYmBqmNnEPGAeUu73f2JMNdmKKgukAARiNrYyx1ZXwo7dCPBhJNb1pbZvCg&Signature=TVRYYG0TugL97P4yMiaLZvrs%2BH0%3D)
+
 ### KCD Developer Exchange, Shenzhen Station
 Held on: 20231216 <br/>
 Meeting PPT: [Download](https://koupleless.oss-cn-shanghai.aliyuncs.com/outer-materials/SOFAServerless%20%E5%BE%AE%E6%9C%8D%E5%8A%A1%E6%96%B0%E6%9E%B6%E6%9E%84%E7%9A%84%E6%8E%A2%E7%B4%A2%E4%B8%8E%E5%AE%9E%E8%B7%B5_20231217_v0.9.1.pdf)

--- a/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
+++ b/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
@@ -8,11 +8,11 @@ weight: 800
 ### Compatibility Relationships Across Different Versions of the Framework
 Users can choose to import the Koupleless version as needed, based on actual JDK and SpringBoot versions.
 
-| JDK    | SpringBoot      | Koupleless       |
-|--------|-----------------|------------------|
-| 1.8    | 2.x             | 1.x.x            |
-| 17     | 3.0.x, 3.1.x    | 2.0.x            |
-| 17 & 21 | 3.2.x and above | 2.1.x            |
+| JDK    | SpringBoot      | SOFA-ARK | Koupleless       |
+|--------|-----------------|----|------------------|
+| 1.8    | 2.x             | 2.x.x | 1.x.x            |
+| 17     | 3.0.x, 3.1.x    | 3.0.x | 2.0.x            |
+| 17 & 21 | 3.2.x and above | 3.1.x | 2.1.x            |
 
 For Koupleless SDK latest versions, please refer to https://github.com/koupleless/runtime/releases
 

--- a/content/zh-cn/blog/external-articles-and-videos.md
+++ b/content/zh-cn/blog/external-articles-and-videos.md
@@ -8,6 +8,10 @@ description: Koupleless 干货文章与视频
 
 ## 技术会议
 
+### 2024 Apache COC 大会
+举办时间：20240726
+会议 PPT: [点击此处下载](https://serverless-opensource.oss-cn-shanghai.aliyuncs.com/outer-materials/%E3%80%90apache%20coc%202024%E3%80%91%E5%BE%AE%E6%9C%8D%E5%8A%A1%E4%B8%8B%E4%B8%80%E7%AB%99%EF%BC%8CKoupleless%20%E6%A8%A1%E5%9D%97%E5%8C%96%E7%A0%94%E5%8F%91%E6%A1%86%E6%9E%B6%E4%B8%8E%E8%BF%90%E7%BB%B4%E8%B0%83%E5%BA%A6%E7%B3%BB%E7%BB%9F-v2.0.pdf?Expires=1721990001&OSSAccessKeyId=TMP.3KiUjg1m2mc2LyZV76WyqYdJVi3b3jDnpeoFYmBqmNnEPGAeUu73f2JMNdmKKgukAARiNrYyx1ZXwo7dCPBhJNb1pbZvCg&Signature=TVRYYG0TugL97P4yMiaLZvrs%2BH0%3D)
+
 ### KCD 开发者交流会 深圳站
 举办时间：20231216 <br/>
 会议 PPT: [点击此处下载](https://koupleless.oss-cn-shanghai.aliyuncs.com/outer-materials/SOFAServerless%20%E5%BE%AE%E6%9C%8D%E5%8A%A1%E6%96%B0%E6%9E%B6%E6%9E%84%E7%9A%84%E6%8E%A2%E7%B4%A2%E4%B8%8E%E5%AE%9E%E8%B7%B5_20231217_v0.9.1.pdf)

--- a/content/zh-cn/docs/tutorials/module-development/runtime-compatibility-list.md
+++ b/content/zh-cn/docs/tutorials/module-development/runtime-compatibility-list.md
@@ -9,11 +9,11 @@ weight: 800
 
 用户可根据实际 jdk 和 springboot 版本按需引入 Koupleless 版本
 
-| JDK     | SpringBoot | Koupleless   |
-|---------|------------|--------------|
-| 1.8     | 2.x        | 1.x.x        |
-| 17      | 3.0.x, 3.1.x | 2.0.x        |
-| 17 & 21 | 3.2.x 以上 | 2.1.x        |
+| JDK    | SpringBoot      | SOFA-ARK | Koupleless       |
+|--------|-----------------|----|------------------|
+| 1.8    | 2.x             | 2.x.x | 1.x.x            |
+| 17     | 3.0.x, 3.1.x    | 3.0.x | 2.0.x            |
+| 17 & 21 | 3.2.x and above | 3.1.x | 2.1.x            |
 
 koupleless 的 sdk 最新版本请查看 https://github.com/koupleless/runtime/releases
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new sections for the "2024 Apache COC" event in both English and Chinese blog documents, including a date and a link to the meeting presentation.
	- Updated compatibility documentation to include a new column for "SOFA-ARK," enhancing clarity of framework compatibility across JDK and SpringBoot versions.

- **Bug Fixes**
	- Improved formatting and alignment in the compatibility tables for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->