### PR TITLE
freeze the jdk 17 version of sofa-ark and koupleless

### DIFF
--- a/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
+++ b/content/en/docs/tutorials/module-development/runtime-compatibility-list.md
@@ -8,11 +8,11 @@ weight: 800
 ### Compatibility Relationships Across Different Versions of the Framework
 Users can choose to import the Koupleless version as needed, based on actual JDK and SpringBoot versions.
 
-| JDK    | SpringBoot      | SOFA-ARK | Koupleless       |
-|--------|-----------------|----|------------------|
-| 1.8    | 2.x             | 2.x.x | 1.x.x            |
-| 17     | 3.0.x, 3.1.x    | 3.0.x | 2.0.x            |
-| 17 & 21 | 3.2.x and above | 3.1.x | 2.1.x            |
+| JDK    | SpringBoot      | SOFA-ARK     | Koupleless  |
+|--------|-----------------|--------------|-------------|
+| 1.8    | 2.x             | 2.x.x        | 1.x.x       |
+| 17     | 3.0.x, 3.1.x    | 3.0.7 (不再更新) | 2.0.4（不再更新） |
+| 17 & 21 | 3.2.x and above | 3.1.x        | 2.1.x       |
 
 For Koupleless SDK latest versions, please refer to https://github.com/koupleless/runtime/releases
 

--- a/content/zh-cn/docs/tutorials/module-development/runtime-compatibility-list.md
+++ b/content/zh-cn/docs/tutorials/module-development/runtime-compatibility-list.md
@@ -9,11 +9,11 @@ weight: 800
 
 用户可根据实际 jdk 和 springboot 版本按需引入 Koupleless 版本
 
-| JDK    | SpringBoot      | SOFA-ARK | Koupleless       |
-|--------|-----------------|----|------------------|
-| 1.8    | 2.x             | 2.x.x | 1.x.x            |
-| 17     | 3.0.x, 3.1.x    | 3.0.x | 2.0.x            |
-| 17 & 21 | 3.2.x and above | 3.1.x | 2.1.x            |
+| JDK    | SpringBoot      | SOFA-ARK                 | Koupleless               |
+|--------|-----------------|--------------------------|--------------------------|
+| 1.8    | 2.x             | 2.x.x                    | 1.x.x                    |
+| 17     | 3.0.x, 3.1.x    | 3.0.7(no update anymore) | 2.0.4(no update anymore) |
+| 17 & 21 | 3.2.x and above | 3.1.x                    | 2.1.x                    |
 
 koupleless 的 sdk 最新版本请查看 https://github.com/koupleless/runtime/releases
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the compatibility tables for the Koupleless framework to improve readability and clarity.
	- Indicated deprecated versions of SOFA-ARK and Koupleless with clear notes for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->